### PR TITLE
fix: separate Archidekt maybeboard/sideboard zones from mainboard count

### DIFF
--- a/archidekt.go
+++ b/archidekt.go
@@ -273,11 +273,70 @@ func archidektPremierCategories(categories []ArchidektCategory) map[string]bool 
 	return premier
 }
 
+// archidektExcludedCategories returns the set of category names explicitly NOT included in the deck
+// (includedInDeck == false), e.g. "Maybeboard".
+func archidektExcludedCategories(categories []ArchidektCategory) map[string]bool {
+	excluded := make(map[string]bool)
+	for _, c := range categories {
+		if !c.IncludedInDeck {
+			excluded[c.Name] = true
+		}
+	}
+	return excluded
+}
+
+// Out-of-deck zone names. Commander has no real sideboard, so Archidekt's Sideboard category is
+// always treated as out of the deck (regardless of its includedInDeck flag).
+const (
+	archidektSideboardZone  = "Sideboard"
+	archidektMaybeboardZone = "Maybeboard"
+)
+
+// archidektEntryZone classifies a card entry's out-of-deck zone, returning archidektSideboardZone or
+// archidektMaybeboardZone for cards outside the playable deck, or "" for cards that count toward it.
+// A card belongs to a zone if ANY of its categories matches it, so cards tagged Sideboard alongside a
+// type category (e.g. ["Sideboard", "Creature"]) are still treated as sideboard. excluded holds the
+// category names flagged includedInDeck==false (e.g. Maybeboard).
+func archidektEntryZone(entry ArchidektCardEntry, excluded map[string]bool) string {
+	for _, cat := range entry.Categories {
+		if cat == archidektSideboardZone {
+			return archidektSideboardZone
+		}
+	}
+	for _, cat := range entry.Categories {
+		if excluded[cat] {
+			return archidektMaybeboardZone
+		}
+	}
+	return ""
+}
+
+// archidektEntryInDeck reports whether a card entry counts toward the playable deck (mainboard),
+// i.e. it is not in an out-of-deck zone (Sideboard / Maybeboard).
+func archidektEntryInDeck(entry ArchidektCardEntry, excluded map[string]bool) bool {
+	return archidektEntryZone(entry, excluded) == ""
+}
+
+// formatArchidektZone renders an out-of-deck zone as "## Title (N)" followed by its card lines,
+// or "" when the zone is empty.
+func formatArchidektZone(title string, cards []string) string {
+	if len(cards) == 0 {
+		return ""
+	}
+	var output strings.Builder
+	fmt.Fprintf(&output, "\n## %s (%d)\n", title, len(cards))
+	for _, c := range cards {
+		fmt.Fprintf(&output, "- %s\n", c)
+	}
+	return output.String()
+}
+
 // FormatArchidektDeckForDisplay formats an Archidekt deck for text display.
 func FormatArchidektDeckForDisplay(deck *ArchidektDeck) string {
 	var output strings.Builder
 
 	premier := archidektPremierCategories(deck.Categories)
+	excluded := archidektExcludedCategories(deck.Categories)
 
 	// Header
 	fmt.Fprintf(&output, "# %s\n\n", deck.Name)
@@ -309,8 +368,8 @@ func FormatArchidektDeckForDisplay(deck *ArchidektDeck) string {
 		}
 	}
 
-	// Group mainboard cards by type (exclude commander-category cards)
-	groups := groupArchidektDeckCards(deck.Cards, premier)
+	// Group mainboard cards by type (exclude commander-category and out-of-deck cards)
+	groups := groupArchidektDeckCards(deck.Cards, premier, excluded)
 
 	output.WriteString("\n## Mainboard\n")
 	fmt.Fprintf(&output, "\n**Total Cards:** %d\n\n", groups.totalCards+len(commanders))
@@ -325,6 +384,20 @@ func FormatArchidektDeckForDisplay(deck *ArchidektDeck) string {
 	if len(groups.others) > 0 {
 		output.WriteString(formatCardGroup("Other", groups.others))
 	}
+
+	// Out-of-deck zones (Sideboard / Maybeboard), listed separately
+	var maybeboard, sideboard []string
+	for _, entry := range deck.Cards {
+		line := fmt.Sprintf("%dx %s", entry.Quantity, entry.Card.OracleCard.Name)
+		switch archidektEntryZone(entry, excluded) {
+		case archidektMaybeboardZone:
+			maybeboard = append(maybeboard, line)
+		case archidektSideboardZone:
+			sideboard = append(sideboard, line)
+		}
+	}
+	output.WriteString(formatArchidektZone(archidektMaybeboardZone, maybeboard))
+	output.WriteString(formatArchidektZone(archidektSideboardZone, sideboard))
 
 	return output.String()
 }
@@ -429,6 +502,7 @@ func FormatArchidektLandsForDisplay(deck *ArchidektDeck) string {
 	var output strings.Builder
 
 	premier := archidektPremierCategories(deck.Categories)
+	excluded := archidektExcludedCategories(deck.Categories)
 
 	fmt.Fprintf(&output, "# %s — Landbase\n\n", deck.Name)
 	fmt.Fprintf(&output, "**Author:** %s\n", deck.Owner.Username)
@@ -449,6 +523,10 @@ func FormatArchidektLandsForDisplay(deck *ArchidektDeck) string {
 		if isCommander {
 			continue
 		}
+		// Skip cards outside the deck (Sideboard / Maybeboard)
+		if !archidektEntryInDeck(entry, excluded) {
+			continue
+		}
 		typeLine := strings.ToLower(strings.Join(entry.Card.OracleCard.Types, " "))
 		if strings.Contains(typeLine, "land") {
 			lands = append(lands, fmt.Sprintf("%dx %s", entry.Quantity, entry.Card.OracleCard.Name))
@@ -463,8 +541,9 @@ func FormatArchidektLandsForDisplay(deck *ArchidektDeck) string {
 	return output.String()
 }
 
-// groupArchidektDeckCards categorizes non-commander cards by oracle type.
-func groupArchidektDeckCards(cards []ArchidektCardEntry, premier map[string]bool) deckCardGroups {
+// groupArchidektDeckCards categorizes non-commander, in-deck cards by oracle type,
+// excluding cards that sit outside the deck (Sideboard / Maybeboard).
+func groupArchidektDeckCards(cards []ArchidektCardEntry, premier, excluded map[string]bool) deckCardGroups {
 	groups := deckCardGroups{
 		creatures:     []string{},
 		instants:      []string{},
@@ -486,6 +565,11 @@ func groupArchidektDeckCards(cards []ArchidektCardEntry, premier map[string]bool
 			}
 		}
 		if isCommander {
+			continue
+		}
+
+		// Skip cards outside the deck (Sideboard / Maybeboard)
+		if !archidektEntryInDeck(entry, excluded) {
 			continue
 		}
 

--- a/archidekt.go
+++ b/archidekt.go
@@ -317,14 +317,14 @@ func archidektEntryInDeck(entry ArchidektCardEntry, excluded map[string]bool) bo
 	return archidektEntryZone(entry, excluded) == ""
 }
 
-// formatArchidektZone renders an out-of-deck zone as "## Title (N)" followed by its card lines,
-// or "" when the zone is empty.
+// formatArchidektZone renders an out-of-deck zone as "## Title" followed by its card lines,
+// or "" when the zone is empty. Mirrors the Moxfield deck output style (plain heading, no count).
 func formatArchidektZone(title string, cards []string) string {
 	if len(cards) == 0 {
 		return ""
 	}
 	var output strings.Builder
-	fmt.Fprintf(&output, "\n## %s (%d)\n", title, len(cards))
+	fmt.Fprintf(&output, "\n## %s\n", title)
 	for _, c := range cards {
 		fmt.Fprintf(&output, "- %s\n", c)
 	}
@@ -396,8 +396,8 @@ func FormatArchidektDeckForDisplay(deck *ArchidektDeck) string {
 			sideboard = append(sideboard, line)
 		}
 	}
-	output.WriteString(formatArchidektZone(archidektMaybeboardZone, maybeboard))
 	output.WriteString(formatArchidektZone(archidektSideboardZone, sideboard))
+	output.WriteString(formatArchidektZone(archidektMaybeboardZone, maybeboard))
 
 	return output.String()
 }

--- a/archidekt_test.go
+++ b/archidekt_test.go
@@ -417,6 +417,212 @@ func TestFormatArchidektLandsForDisplay(t *testing.T) {
 	}
 }
 
+func TestFormatArchidektDeckMaybeboardSeparated(t *testing.T) {
+	deck := &ArchidektDeck{
+		ID:         555,
+		Name:       "Maybe Deck",
+		DeckFormat: 3,
+		Owner:      ArchidektOwner{Username: "tester"},
+		Categories: []ArchidektCategory{
+			{ID: 1, Name: "Commander", IsPremier: true, IncludedInDeck: true},
+			{ID: 2, Name: "Creature", IsPremier: false, IncludedInDeck: true},
+			{ID: 3, Name: "Maybeboard", IsPremier: false, IncludedInDeck: false},
+		},
+		Cards: []ArchidektCardEntry{
+			{
+				Quantity:   1,
+				Categories: []string{"Commander"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Atraxa, Praetors' Voice", Types: []string{"Creature"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Creature"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Llanowar Elves", Types: []string{"Creature"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Maybeboard"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Maybe Card", Types: []string{"Sorcery"}},
+				},
+			},
+		},
+	}
+
+	got := FormatArchidektDeckForDisplay(deck)
+
+	if !strings.Contains(got, "## Maybeboard") {
+		t.Fatalf("expected a Maybeboard section in output:\n%s", got)
+	}
+
+	mainPart, maybePart, _ := strings.Cut(got, "## Maybeboard")
+
+	if strings.Contains(mainPart, "Maybe Card") {
+		t.Error("maybeboard card should not appear in the Mainboard section")
+	}
+	if !strings.Contains(maybePart, "Maybe Card") {
+		t.Error("maybeboard card should appear in the Maybeboard section")
+	}
+	if !strings.Contains(mainPart, "Llanowar Elves") {
+		t.Error("mainboard creature missing from Mainboard section")
+	}
+	if !strings.Contains(mainPart, "**Total Cards:** 2") {
+		t.Errorf("Total Cards should be 2 (commander + 1 mainboard), excluding maybeboard; got:\n%s", mainPart)
+	}
+}
+
+func TestFormatArchidektLandsExcludesMaybeboard(t *testing.T) {
+	deck := &ArchidektDeck{
+		ID:         556,
+		Name:       "Maybe Lands",
+		DeckFormat: 3,
+		Owner:      ArchidektOwner{Username: "tester"},
+		Categories: []ArchidektCategory{
+			{ID: 1, Name: "Commander", IsPremier: true, IncludedInDeck: true},
+			{ID: 2, Name: "Land", IsPremier: false, IncludedInDeck: true},
+			{ID: 3, Name: "Maybeboard", IsPremier: false, IncludedInDeck: false},
+		},
+		Cards: []ArchidektCardEntry{
+			{
+				Quantity:   1,
+				Categories: []string{"Land"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Command Tower", Types: []string{"Land"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Maybeboard"},
+				Card:       ArchidektCard{OracleCard: ArchidektOracleCard{Name: "Bojuka Bog", Types: []string{"Land"}}},
+			},
+		},
+	}
+
+	got := FormatArchidektLandsForDisplay(deck)
+
+	if !strings.Contains(got, "Command Tower") {
+		t.Error("mainboard land should appear in lands-only output")
+	}
+	if strings.Contains(got, "Bojuka Bog") {
+		t.Error("maybeboard land should not appear in lands-only output")
+	}
+}
+
+func TestFormatArchidektDeckSideboardSeparated(t *testing.T) {
+	deck := &ArchidektDeck{
+		ID:         557,
+		Name:       "Side Deck",
+		DeckFormat: 3,
+		Owner:      ArchidektOwner{Username: "tester"},
+		Categories: []ArchidektCategory{
+			{ID: 1, Name: "Commander", IsPremier: true, IncludedInDeck: true},
+			{ID: 2, Name: "Creature", IsPremier: false, IncludedInDeck: true},
+			// Archidekt flags Sideboard as includedInDeck=true, but in Commander it is out of the deck.
+			{ID: 3, Name: "Sideboard", IsPremier: false, IncludedInDeck: true},
+		},
+		Cards: []ArchidektCardEntry{
+			{
+				Quantity:   1,
+				Categories: []string{"Commander"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Atraxa, Praetors' Voice", Types: []string{"Creature"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Creature"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Llanowar Elves", Types: []string{"Creature"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Sideboard"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Pithing Needle", Types: []string{"Artifact"}},
+				},
+			},
+			{
+				// Mixed category: tagged Sideboard AND a type — must still be treated as sideboard.
+				Quantity:   1,
+				Categories: []string{"Sideboard", "Creature"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Scavenging Ooze", Types: []string{"Creature"}},
+				},
+			},
+		},
+	}
+
+	got := FormatArchidektDeckForDisplay(deck)
+
+	if !strings.Contains(got, "## Sideboard") {
+		t.Fatalf("expected a Sideboard section in output:\n%s", got)
+	}
+
+	mainPart, sidePart, _ := strings.Cut(got, "## Sideboard")
+
+	if strings.Contains(mainPart, "Pithing Needle") {
+		t.Error("sideboard card should not appear in the Mainboard section")
+	}
+	if strings.Contains(mainPart, "Scavenging Ooze") {
+		t.Error("mixed-category sideboard card should not appear in the Mainboard section")
+	}
+	if !strings.Contains(sidePart, "Pithing Needle") {
+		t.Error("sideboard card should appear in the Sideboard section")
+	}
+	if !strings.Contains(sidePart, "Scavenging Ooze") {
+		t.Error("mixed-category sideboard card should appear in the Sideboard section")
+	}
+	if !strings.Contains(mainPart, "Llanowar Elves") {
+		t.Error("mainboard creature missing from Mainboard section")
+	}
+	if !strings.Contains(mainPart, "**Total Cards:** 2") {
+		t.Errorf("Total Cards should be 2 (commander + 1 mainboard), excluding sideboard; got:\n%s", mainPart)
+	}
+}
+
+func TestFormatArchidektLandsExcludesSideboard(t *testing.T) {
+	deck := &ArchidektDeck{
+		ID:         558,
+		Name:       "Side Lands",
+		DeckFormat: 3,
+		Owner:      ArchidektOwner{Username: "tester"},
+		Categories: []ArchidektCategory{
+			{ID: 1, Name: "Land", IsPremier: false, IncludedInDeck: true},
+			{ID: 2, Name: "Sideboard", IsPremier: false, IncludedInDeck: true},
+		},
+		Cards: []ArchidektCardEntry{
+			{
+				Quantity:   1,
+				Categories: []string{"Land"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Command Tower", Types: []string{"Land"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Sideboard"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Reliquary Tower", Types: []string{"Land"}},
+				},
+			},
+		},
+	}
+
+	got := FormatArchidektLandsForDisplay(deck)
+
+	if !strings.Contains(got, "Command Tower") {
+		t.Error("mainboard land should appear in lands-only output")
+	}
+	if strings.Contains(got, "Reliquary Tower") {
+		t.Error("sideboard land should not appear in lands-only output")
+	}
+}
+
 func TestSearchArchidektDecks(t *testing.T) {
 	bracket4 := 4
 	bracket2 := 2

--- a/archidekt_test.go
+++ b/archidekt_test.go
@@ -623,6 +623,69 @@ func TestFormatArchidektLandsExcludesSideboard(t *testing.T) {
 	}
 }
 
+func TestFormatArchidektZonesMatchMoxfieldStyle(t *testing.T) {
+	deck := &ArchidektDeck{
+		ID:         559,
+		Name:       "Zones Deck",
+		DeckFormat: 3,
+		Owner:      ArchidektOwner{Username: "tester"},
+		Categories: []ArchidektCategory{
+			{ID: 1, Name: "Commander", IsPremier: true, IncludedInDeck: true},
+			{ID: 2, Name: "Creature", IsPremier: false, IncludedInDeck: true},
+			{ID: 3, Name: "Sideboard", IsPremier: false, IncludedInDeck: true},
+			{ID: 4, Name: "Maybeboard", IsPremier: false, IncludedInDeck: false},
+		},
+		Cards: []ArchidektCardEntry{
+			{
+				Quantity:   1,
+				Categories: []string{"Commander"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Atraxa, Praetors' Voice", Types: []string{"Creature"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Creature"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Llanowar Elves", Types: []string{"Creature"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Sideboard"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Pithing Needle", Types: []string{"Artifact"}},
+				},
+			},
+			{
+				Quantity:   1,
+				Categories: []string{"Maybeboard"},
+				Card: ArchidektCard{
+					OracleCard: ArchidektOracleCard{Name: "Demonic Tutor", Types: []string{"Sorcery"}},
+				},
+			},
+		},
+	}
+
+	got := FormatArchidektDeckForDisplay(deck)
+
+	// Moxfield style: plain headers with no "(N)" count.
+	if strings.Contains(got, "## Sideboard (") || strings.Contains(got, "## Maybeboard (") {
+		t.Errorf("zone headers must not include a count to match Moxfield style; got:\n%s", got)
+	}
+	if !strings.Contains(got, "## Sideboard\n") {
+		t.Error("expected plain '## Sideboard' header")
+	}
+	if !strings.Contains(got, "## Maybeboard\n") {
+		t.Error("expected plain '## Maybeboard' header")
+	}
+
+	// Moxfield order: Sideboard before Maybeboard.
+	if strings.Index(got, "## Sideboard") > strings.Index(got, "## Maybeboard") {
+		t.Error("Sideboard section should come before Maybeboard, matching Moxfield order")
+	}
+}
+
 func TestSearchArchidektDecks(t *testing.T) {
 	bracket4 := 4
 	bracket2 := 2


### PR DESCRIPTION
## Problem

Archidekt deck JSON marks each category with an `includedInDeck` flag, but the parser ignored it. Maybeboard (`includedInDeck=false`) and Sideboard cards were counted into the Mainboard, inflating the total — e.g. deck `23473154` reported **124 cards instead of 100**.

## Fix

- Classify each card entry into an out-of-deck zone:
  - **Maybeboard**: any category flagged `includedInDeck=false`
  - **Sideboard**: any category named `Sideboard` — Commander has no real sideboard, so it is always out of the deck even though Archidekt flags it `includedInDeck=true`
- Zone membership uses ANY semantics, so mixed-category cards like `["Sideboard","Creature"]` are still treated as out-of-deck.
- Mainboard grouping and the `lands_only` output skip both zones.
- The deck view renders separate `## Sideboard` and `## Maybeboard` sections, styled to match the existing Moxfield output: plain headers without a `(N)` count, Sideboard before Maybeboard.

## Tests

New cases in `archidekt_test.go` covering:
- zone classification (Sideboard / Maybeboard / mainboard)
- mainboard count correctness (no inflation from out-of-deck cards)
- `lands_only` excluding sideboard lands
- Moxfield-style zone rendering and Sideboard-before-Maybeboard order

🤖 Generated with [Claude Code](https://claude.com/claude-code)